### PR TITLE
Update minimum requests version to 2.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ bunch >=1.0.0
 # 0.14 switches to libev, that means bootstrap needs to change too
 gevent >=1.0
 isodate >=0.4.4
-requests >=0.14.0
+requests >=2.10.0
 pytz >=2011k
 ordereddict
 httplib2


### PR DESCRIPTION
By default it install 0.14.0 version and it will break test like test_post_object_anonymous_request with error message:
'module' object has no attribute 'PROTOCOL_SSLv3'. 
This might be the minimum working package